### PR TITLE
[Recipe/NNStreamer] Bump up to v1.5.3

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "neuralnetwork"
 
 BBFILE_PATTERN_neuralnetwork = "^${LAYERDIR}/"
 BBFILE_PRIORITY_neuralnetwork = "7"
-LAYERVERSION_neuralnetwork = "4"
-LAYERSERIES_COMPAT_neuralnetwork = "thud warrior"
+LAYERVERSION_neuralnetwork = "5"
+LAYERSERIES_COMPAT_neuralnetwork = "zeus"

--- a/recipes-nnstreamer/nnstreamer/files/0001-Test-Common-Remove-a-unit-test-for-custom-configurat.patch
+++ b/recipes-nnstreamer/nnstreamer/files/0001-Test-Common-Remove-a-unit-test-for-custom-configurat.patch
@@ -1,25 +1,28 @@
-From 17f17c3b0dc9b7dfd131a70a8ae34efeef7bcff0 Mon Sep 17 00:00:00 2001
+From ee2dc1fb4952597faa2b7a8eabf6dc3b5ccd96e0 Mon Sep 17 00:00:00 2001
 From: Wook Song <wook16.song@samsung.com>
-Date: Mon, 23 Sep 2019 09:41:15 +0900
+Date: Mon, 15 Jun 2020 12:59:22 +0900
 Subject: [PATCH 1/1] [Test/Common] Remove a unit test for custom configuration
 
-This patch removes a unit test for custom configuration file provided by
-the environment variable since once nnstreamer is installed the
-configuration file cannot be overrided using the environment variable.
+Since there is no way to override the location of the configuration file
+after it is installed, such types of test cases should be skipped when
+the test cases are required to be run after installation. For this reason,
+this patch removes unit test cases for the configuration file provided by
+the environment variable.
 
 Signed-off-by: Wook Song <wook16.song@samsung.com>
 ---
- tests/common/unittest_common.cpp | 149 ---------------------------------------
+ tests/common/unittest_common.cc | 149 --------------------------------
  1 file changed, 149 deletions(-)
 
-diff --git a/tests/common/unittest_common.cpp b/tests/common/unittest_common.cpp
-index 5d00638..876cb6d 100644
---- a/tests/common/unittest_common.cpp
-+++ b/tests/common/unittest_common.cpp
-@@ -606,155 +606,6 @@ static gchar *create_null_file (const gchar *dir, const gchar *file)
+diff --git a/tests/common/unittest_common.cc b/tests/common/unittest_common.cc
+index 20814c7b..00326f88 100644
+--- a/tests/common/unittest_common.cc
++++ b/tests/common/unittest_common.cc
+@@ -800,155 +800,6 @@ static gchar *create_null_file (const gchar *dir, const gchar *file)
+   return fullpath;
  }
  
- /**
+-/**
 - * @brief Check string custom conf
 - */
 -static gboolean check_custom_conf (const gchar *group, const gchar *key, const gchar *expected)
@@ -168,10 +171,9 @@ index 5d00638..876cb6d 100644
 -  g_free (f6);
 -}
 -
--/**
+ /**
   * @brief Main function for unit test.
   */
- int
 -- 
-2.7.4
+2.17.1
 

--- a/recipes-nnstreamer/nnstreamer/nnstreamer_1.5.3.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_1.5.3.bb
@@ -11,28 +11,24 @@ DEPENDS = "orc-native glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gtest"
 DEPENDS += "\
         ${@bb.utils.contains('DISTRO_FEATURES','tensorflow-lite','tensorflow-lite','',d)} \
         "
-DEPENDS += "python python-numpy python3 python3-numpy"
+DEPENDS += "python3 python3-numpy"
 
 SRC_URI = "\
         git://github.com/nnsuite/nnstreamer.git;protocol=https \
         file://0001-Test-Common-Remove-a-unit-test-for-custom-configurat.patch \
         "
 
-PV = "1.0.0+git${SRCPV}"
-SRCREV = "720ce6ec7f68325dfd1e6c2ded6024e805f3eff2"
+PV = "1.5.3+git${SRCPV}"
+SRCREV = "830680015e45b66bd4d0df04861ba38171257b2c"
 
 S = "${WORKDIR}/git"
 
 inherit meson pkgconfig
 
 EXTRA_OEMESON += "\
-                -Denable-orc=true \
                 -Denable-test=true \
                 -Dinstall-test=true \
-                -Denable-pytorch=false \
-                -Denable-caffe2=false \
                 -Dinstall-example=true \
-                -Ddisable-audio-support=false \
                 "
 
 PACKAGECONFIG ??= "\
@@ -40,9 +36,6 @@ PACKAGECONFIG ??= "\
                 ${@bb.utils.contains('DISTRO_FEATURES','tensorflow','tensorflow','',d)} \
                 ${@bb.utils.contains('DISTRO_FEATURES','tensorflow-lite','tensorflow-lite','',d)} \
                 "
-
-PACKAGECONFIG[tensorflow] = "-Denable-tensorflow=true,-Denable-tensorflow=false,tensorflow"
-PACKAGECONFIG[tensorflow-lite] = "-Denable-tensorflow-lite=true,-Denable-tensorflow-lite=false,tensorflow-lite"
 
 do_install_append() {
     (cd ${D}/${libdir}; ln -s ./gstreamer-1.0/libnnstreamer.so)
@@ -69,18 +62,17 @@ FILES_${PN}-tensorflow-lite += "\
                             "
 
 RDEPENDS_${PN}-unittest = "nnstreamer gstreamer1.0-plugins-good ssat"
-RDEPENDS_${PN}-unittest += "python python-numpy python-numbers python-unittest python-misc"
 RDEPENDS_${PN}-unittest += "\
                         ${@bb.utils.contains('DISTRO_FEATURES','tensorflow-lite', \
                             '${PN}-tensorflow-lite','',d)} \
                         "
 
 RDEPENDS_${PN} = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base"
-RDEPENDS_${PN} += "python python-numpy python-math"
 RDEPENDS_${PN} += "python3 python3-numpy python3-math"
 
 FILES_${PN}-dev = "\
                 ${includedir}/nnstreamer/* \
                 ${libdir}/*.a \
                 ${libdir}/pkgconfig/nnstreamer.pc \
+                ${libdir}/pkgconfig/nnstreamer-cpp.pc \
                 "


### PR DESCRIPTION
This patch bumps up the version of NNStreamer to v1.5.3 (v1.6.0-RC4). To this end, LAYERSERIES_COMPAT is revised to include 'zeus' instead of 'thud' and 'warrior' which do not support meson (>= v0.50). In addition, dependencies on Python 2.7 are also removed from the bitbake recipe.

Note that Dunfell (the first LTS release of Yocto project) will be also added to LAYERSERIES_COMPAT soon.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Build tests are done for qemu-x64 and qemu-arm64.