### PR TITLE
[Recipe/TFLite] Revise the bitbake recipe for TFLite 1.15.2 to support nnstreamer

### DIFF
--- a/recipes-tensorflow/tensorflow-lite/files/tensorflow-lite.pc.in
+++ b/recipes-tensorflow/tensorflow-lite/files/tensorflow-lite.pc.in
@@ -2,5 +2,5 @@
  Description: tensorflow lite static library
  Version: @version@
  Requires:
- Libs: -L@libdir@ -ltensorflow-lite
+ Libs: -L@libdir@ -ltensorflow-lite -lrt
  Cflags: -I@includedir@

--- a/recipes-tensorflow/tensorflow-lite/tensorflow-lite_1.15.2.bb
+++ b/recipes-tensorflow/tensorflow-lite/tensorflow-lite_1.15.2.bb
@@ -94,6 +94,10 @@ do_install() {
         install -m 0644 "${file}" "${D}${includedir}/tensorflow/lite/${file}"
     done
 
+    # For backward compatibility with v1.09, where tf-lite was in contrib
+    mkdir -p ${D}${includedir}/tensorflow/contrib
+    cd ${D}${includedir}/tensorflow/contrib && ln -sf ../lite
+
     sed -i 's:@version@:${PV}:g
         s:@libdir@:${libdir}:g
         s:@includedir@:${includedir}:g' ${D}${libdir}/pkgconfig/tensorflow-lite.pc


### PR DESCRIPTION
To support nnstreamer, this PR includes the following patches:
 - [Recipe/TFLite] Keep backward compatibility with v1.09
   - NNStreamer uses tensorflow/contrib/lite/*.h to keep backward compatibility with v1.09. To this end, this patch creates a symlink to tensorflow/lite in tensorflow/contrib.

 - [Recipe/TFLite] Add -lrt to the .pc template file for tf-lite 
  - NnApi uses shm_open() so that the link option, -lrt, is required to build with the tensorflow-lite library. This patch fixes it by adding -lrt to the Libs field of the .pc template file.

Related to https://github.com/nnstreamer/nnstreamer/issues/2740 and https://github.com/nnstreamer/nnstreamer/issues/2732

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>