### PR TITLE
[OEQA/NNStreamer] Drop OETestID

### DIFF
--- a/lib/oeqa/runtime/cases/nnstreamer.py
+++ b/lib/oeqa/runtime/cases/nnstreamer.py
@@ -2,12 +2,10 @@ import os
 from subprocess import Popen, PIPE
 
 from oeqa.runtime.case import OERuntimeTestCase
-from oeqa.core.decorator.oeid import OETestID
 from oeqa.core.decorator.oetimeout import OETimeout
 
 class NNStreamerTest(OERuntimeTestCase):
 
-    @OETestID(3001)
     def test_nnstreamer(self):
         cmd = 'export LD_LIBRARY_PATH=/usr/lib/gstreamer-1.0:$LD_LIBRARY_PATH; ' \
         '/usr/lib/nnstreamer/unittest/unittest_common'


### PR DESCRIPTION
OETestID has been dropped in OE-Core. In order to make the test script, nnstreamer.py, compatible with 'zeus', this patch removes the OETestID relevant code from the script.

See also: http://git.yoctoproject.org/cgit.cgi/poky/commit/?h=zeus&id=c7592b01478def091b6787412390c61e7ce0a0cd
Related to https://github.com/nnstreamer/nnstreamer/issues/2740 and https://github.com/nnstreamer/nnstreamer/issues/2732

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped