### PR TITLE
[Recipe/nntrainer] Add recipe for nntrainer

### DIFF
--- a/recipes-blas/openblas/files/0001-Modify-makefile-for-yocto.patch
+++ b/recipes-blas/openblas/files/0001-Modify-makefile-for-yocto.patch
@@ -1,0 +1,44 @@
+From bc9476ad859b7e582b89f532f5e84771d6e026d2 Mon Sep 17 00:00:00 2001
+From: Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+Date: Fri, 16 Oct 2020 14:22:38 +0900
+Subject: [PATCH] Modify makefile for yocto
+
+- Modify makefile for yocto make build support
+
+Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+---
+ Makefile.install | 4 ++--
+ Makefile.system  | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.install b/Makefile.install
+index dad869f4..1bfdb94b 100644
+--- a/Makefile.install
++++ b/Makefile.install
+@@ -128,8 +128,8 @@ endif
+ 
+ #Generating openblas.pc
+ 	@echo Generating openblas.pc in "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)"
+-	@echo 'libdir='$(OPENBLAS_LIBRARY_DIR) > "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)/openblas.pc"
+-	@echo 'includedir='$(OPENBLAS_INCLUDE_DIR) >> "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)/openblas.pc"
++	@echo 'libdir='$(libdir) > "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)/openblas.pc"
++	@echo 'includedir='$(includedir) >> "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)/openblas.pc"
+ 	@echo 'openblas_config= USE_64BITINT='$(USE_64BITINT) 'DYNAMIC_ARCH='$(DYNAMIC_ARCH) 'DYNAMIC_OLDER='$(DYNAMIC_OLDER) 'NO_CBLAS='$(NO_CBLAS) 'NO_LAPACK='$(NO_LAPACK) 'NO_LAPACKE='$(NO_LAPACKE) 'NO_AFFINITY='$(NO_AFFINITY) 'USE_OPENMP='$(USE_OPENMP) $(CORE) 'MAX_THREADS='$(NUM_THREADS)>> "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)/openblas.pc"
+ 	@echo 'version='$(VERSION) >> "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)/openblas.pc"
+ 	@echo 'extralib='$(EXTRALIB) >> "$(DESTDIR)$(OPENBLAS_PKGCONFIG_DIR)/openblas.pc"
+diff --git a/Makefile.system b/Makefile.system
+index 8d78b420..4d1eab68 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -1184,7 +1184,7 @@ endif
+ 
+ KERNELDIR	= $(TOPDIR)/kernel/$(ARCH)
+ 
+-include $(TOPDIR)/Makefile.$(ARCH)
++# include $(TOPDIR)/Makefile.$(ARCH)
+ 
+ CCOMMON_OPT     += -UASMNAME -UASMFNAME -UNAME -UCNAME -UCHAR_NAME -UCHAR_CNAME
+ CCOMMON_OPT	+= -DASMNAME=$(FU)$(*F) -DASMFNAME=$(FU)$(*F)$(BU) -DNAME=$(*F)$(BU) -DCNAME=$(*F) -DCHAR_NAME=\"$(*F)$(BU)\" -DCHAR_CNAME=\"$(*F)\"
+-- 
+2.17.1
+

--- a/recipes-blas/openblas/openblas_0.3.10.bb
+++ b/recipes-blas/openblas/openblas_0.3.10.bb
@@ -1,0 +1,51 @@
+DESCRIPTION = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
+SUMMARY = "OpenBLAS : An optimized BLAS library"
+HOMEPAGE = "http://www.openblas.net/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5adf4792c949a00013ce25d476a2abc0"
+
+
+SRC_URI = "\
+    https://github.com/xianyi/OpenBLAS/archive/v${PV}.tar.gz;downloadfilename=${BP}.tar.gz \
+    file://0001-Modify-makefile-for-yocto.patch \
+"
+
+SRC_URI[md5sum] = "4727a1333a380b67c8d7c7787a3d9c9a"
+
+S = "${WORKDIR}/OpenBLAS-${PV}"
+
+def map_arch(d):
+    import re
+    arch = d.getVar('TARGET_ARCH', True)
+    if   re.match('i.86$', arch):    return 'ATOM'
+    elif re.match('x86_64$', arch):  return 'ATOM'
+    elif re.match('aarch32$', arch): return 'CORTEXA9'
+    elif re.match('aarch64$', arch): return 'ARMV8'
+    return 'CORTEXA15'
+
+def map_bits(d):
+    import re
+    arch = d.getVar('TARGET_ARCH', True)
+    if   re.match('i.86$', arch):    return 32
+    elif re.match('x86_64$', arch):  return 64
+    elif re.match('aarch32$', arch): return 32
+    elif re.match('aarch64$', arch): return 64
+    return 32
+
+EXTRA_OEMAKE = "\
+    ONLY_CBLAS=1 \
+    HOSTCC=${BUILD_CC} \
+    CROSS=1 \
+    CROSS_SUFFIX=${TARGET_PREFIX} \
+    BINARY=${@map_bits(d)} \
+    TARGET=${@map_arch(d)} \
+    OPENBLAS_LIBRARY_DIR=${D}${libdir} \
+"
+
+do_install() {
+    oe_runmake PREFIX=${D}${prefix} install
+    rm -rf ${D}${bindir} ${D}${libdir}/cmake
+}
+
+FILES_${PN}-dev = "${includedir} ${libdir}/lib${PN}.so"
+FILES_${PN}     = "${libdir}/*"

--- a/recipes-nntrainer/nntrainer/files/0001-Patch-for-yocto-build.patch
+++ b/recipes-nntrainer/nntrainer/files/0001-Patch-for-yocto-build.patch
@@ -1,0 +1,75 @@
+From f5a0c133e91a3892e86c09b1e2a428abac0b6c54 Mon Sep 17 00:00:00 2001
+From: Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+Date: Fri, 16 Oct 2020 16:56:51 +0900
+Subject: [PATCH] Patch for yocto build
+
+- Fix build script to resolve openblas and iniparser
+- Mark jsoncpp and curl to be not required
+
+Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+---
+ meson.build | 33 +++++++++++++++++++++++----------
+ 1 file changed, 23 insertions(+), 10 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 91e5e6d..eb035bb 100644
+--- a/meson.build
++++ b/meson.build
+@@ -94,11 +94,7 @@ endif
+ 
+ if get_option('enable-blas')
+   add_project_arguments('-DUSE_BLAS=1', language:['c','cpp'])
+-  if build_platform == 'tizen'
+-    blas_dep = dependency('openblas')
+-  else
+-    blas_dep = dependency('blas-openblas')
+-  endif
++  blas_dep = dependency('openblas')
+ endif
+ 
+ if get_option('use_gym')
+@@ -116,19 +112,36 @@ endif
+ libm_dep = cxx.find_library('m') # cmath library
+ libdl_dep = cxx.find_library('dl') # DL library
+ thread_dep = dependency('threads') # pthread for tensorflow-lite
+-iniparser_dep = dependency('iniparser', required : false) # iniparser
++
++sysroot = run_command(
++    cxx.cmd_array() + ['-print-sysroot']
++    ).stdout().split('\n')[0]
++
++if sysroot.startswith('/')
++  sysroot_inc_cflags_template = '-I@0@/usr/include@1@'
++  sysroot_inc = sysroot_inc_cflags_template.format(sysroot, '')
++  add_project_arguments(sysroot_inc, language: ['c', 'cpp'])
++  sysroot_inc_cflags_iniparser = sysroot_inc_cflags_template.format(sysroot,
++      '/iniparser')
++else
++  sysroot_inc_cflags_iniparser = '-I/usr/include/iniparser'
++endif
++
++iniparser_dep = dependency('iniparser', required: false) # iniparser
+ if not iniparser_dep.found()
+   message('falling back to find libiniparser library and header files')
+   libiniparser_dep = cxx.find_library('iniparser')
+   if libiniparser_dep.found() and cxx.has_header('iniparser.h', \
+-        args : '-I/usr/include/iniparser')
++        args : sysroot_inc_cflags_iniparser)
+     iniparser_dep = declare_dependency (dependencies : libiniparser_dep,
+-      compile_args : '-I/usr/include/iniparser')
++      compile_args : sysroot_inc_cflags_iniparser)
++  else
++      error('Failed to resolve dependency on iniparser')
+   endif
+ endif
+ 
+-jsoncpp_dep = dependency('jsoncpp') # jsoncpp
+-libcurl_dep = dependency('libcurl')
++jsoncpp_dep = dependency('jsoncpp', required: false) # jsoncpp
++libcurl_dep = dependency('libcurl', required: false)
+ gtest_dep = dependency('gtest', required: false)
+ 
+ # Install .pc
+-- 
+2.17.1
+

--- a/recipes-nntrainer/nntrainer/nntrainer_0.1.1.bb
+++ b/recipes-nntrainer/nntrainer/nntrainer_0.1.1.bb
@@ -1,0 +1,71 @@
+SUMMARY = "NNtrainer, Software framework for training neural networks"
+DESCRIPTION = "NNtrainer is Software Framework for Training Neural Network Models on Devices."
+
+SECTION = "AI"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE;md5=095e13fef457e259d3bc155d0ed859f1 \
+    file://debian/copyright;md5=06434e412e1de1e75fbd4f42920ebc4e \
+"
+
+SRC_URI = "\
+    git://github.com/nnstreamer/nntrainer;branch=main;protocol=https \
+    file://0001-Patch-for-yocto-build.patch \
+"
+
+DEPENDS = "\
+    iniparser \
+    openblas \
+    gtest \
+"
+
+PV = "0.1.1+git${SRCPV}"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+inherit meson pkgconfig
+
+EXTRA_OEMESON += "\
+    -Denable-tizen=false \
+    -Denable-blas=true \
+    -Denable-cublas=false \
+    -Denable-app=false \
+    -Dinstall-app=false \
+    -Duse_gym=false \
+    -Denable-capi=true \
+    -Denable-test=true \
+    -Denable-logging=true \
+    -Denable-tizen-feature-check=true \
+    -Denable-nnstreamer-tensor-filter=false \
+    --bindir=${libdir}/${PN}/bin \
+"
+
+do_install_append() {
+    install -m 0644 ${WORKDIR}/build/*.dat ${D}${libdir}/${PN}/bin/applications/
+    install -m 0644 ${WORKDIR}/build/*.in ${D}${libdir}/${PN}/bin/applications/
+    install -m 0644 ${WORKDIR}/build/*.out ${D}${libdir}/${PN}/bin/applications/
+}
+
+INSANE_SKIP_${PN} += "staticdev"
+
+PACKAGES += "\
+    ${PN}-unittest \
+"
+
+FILES_${PN} += "\
+    ${libdir}/*.so \
+"
+
+FILES_${PN}-unittest += "\
+    ${bindir}/applications/unittest* \
+"
+
+FILES_${PN}-dev = "\
+    ${includedir}/nntrainer/* \
+    ${libdir}/*.a \
+    ${bindir}/applications/libapp_utils.a \
+    ${libdir}/pkgconfig/*.pc \
+"
+
+RDEPENDS_${PN}-unittest = "nntrainer"


### PR DESCRIPTION
- Add recipes and patches for iniparser and openblas which nntrainer requires
- This recipe for nntrainer fetch the main branch of nntrainer.git and packaging it
- You could check the unittest binaries at `/usr/lib/nntrainer/bin/applications/unittest_*`

- TODO: Add package `nntrainer-application` and resolve deps

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
