### PR TITLE
CODEOWNERS: fix: remove trailing empty line.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,3 @@
 
 # All members of nnstreamer-team are supposed to review each other
 * @nnstreamer/nnstreamer @myungjoo @jijoongmoon @again4you @jaeyun-jung @leemgs @wooksong @helloahn @kparichay @dongju-chae @gichan-jang @anyj0527 @zhoonit
-


### PR DESCRIPTION
CODEOWNERS of github is very peaky (buggy) with formats.
Remove the trailing empty line.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

