### PR TITLE
[Fix] Fix recipes to be built

### DIFF
--- a/recipes-devtools/ssat/ssat_1.0.0.bb
+++ b/recipes-devtools/ssat/ssat_1.0.0.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://debian/copyright;md5=9ad9849cc2d52d5b8200d053d510e7d2"
 
-SRC_URI = "git://github.com/myungjoo/SSAT;protocol=https"
+SRC_URI = "git://github.com/myungjoo/SSAT;branch=main;protocol=https"
 
 PV = "1.0.0+git${SRCPV}"
 SRCREV = "${AUTOREV}"

--- a/recipes-nnstreamer/nnstreamer/nnstreamer_1.7.2.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_1.7.2.bb
@@ -34,6 +34,7 @@ EXTRA_OEMESON += "\
                 -Denable-test=true \
                 -Dinstall-test=true \
                 -Dskip-tflite-flatbuf-check=true \
+                -Denable-pbtxt-converter=false \
                 "
 
 PACKAGECONFIG ??= "\
@@ -42,7 +43,7 @@ PACKAGECONFIG ??= "\
                 "
 
 do_install_append() {
-    (cd ${D}/${libdir}; ln -s ./gstreamer-1.0/libnnstreamer.so)
+   rm ${D}/${bindir}/unittest-nnstreamer/tests/test_models/models/tvm*
 }
 INSANE_SKIP_${PN} += "dev-so"
 
@@ -62,7 +63,7 @@ PACKAGES =+ "\
 
 FILES_${PN}-unittest += "\
                     ${libdir}/nnstreamer/customfilters/* \
-                    ${libdir}/nnstreamer/unittest/* \
+                    ${bindir}/unittest-nnstreamer/* \
                     "
 
 FILES_${PN}-tensorflow-lite += "\


### PR DESCRIPTION
- Set proper branch name for ssat
- Fix recipe for nnstreamer:
  remove unnecessary files tvm_*.so
  disable pbtxt converter
  change unittest path

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
