### PR TITLE
[nnstreamer] Fix the QA issue for the LICENSE on kirkstone

### DIFF
--- a/recipes-nnstreamer/nnstreamer/nnstreamer_2.1.0.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_2.1.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "NNStreamer, Stream Pipeline Paradigm for Nerual Network Applications"
 DESCRIPTION = "NNStreamer is a GStreamer plugin allowing to construct neural network applications with stream pipeline paradigm."
 SECTION = "AI"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "\
                 file://LICENSE;md5=c25e5c1949624d71896127788f1ba590 \
                 file://debian/copyright;md5=0462ef8fa89a1f53f2e65e74940519ef \


### PR DESCRIPTION
QA issue occurs for the nnstreamer on kirkstone. So it should be updated property. Refer to below license changes for the yocto kirkstone.
https://docs.yoctoproject.org/dev/migration-guides/migration-4.0.html#license-changes.

<ERROR Messages>
ERROR: nnstreamer-2.1.0+gitAUTOINC+b251e9bc6b-r0 do_package_qa: QA Issue: Recipe LICENSE includes obsolete licenses LGPLv2.1 [obsolete-license] ERROR: nnstreamer-2.1.0+gitAUTOINC+b251e9bc6b-r0 do_package_qa: Fatal QA errors were found, failing task.


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```

